### PR TITLE
Providing article url option

### DIFF
--- a/_extensions/aea/partials/before-body.tex
+++ b/_extensions/aea/partials/before-body.tex
@@ -5,7 +5,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 $if(date)$
-\date{\href{https://hchulkim.github.io}{Link to Latest version}\\ \vspace{1em} Last updated $date$}
+\date{$if(articleurl)$\href{$articleurl$}{Link to Latest version}\\ \vspace{1em} $endif$ Last updated $date$}
 $endif$
 $if(journal.blinded)$
 \spacingset{.8}


### PR DESCRIPTION
Thanks for making this. You have it hardcoded right now to use the url of your website if someone includes the date. This adds an `articleurl` option and then includes a link to the most recent only if both that and the date  is included. 